### PR TITLE
fix forbidden script errors and add reprocess button to popup

### DIFF
--- a/html/popup.html
+++ b/html/popup.html
@@ -31,7 +31,7 @@
                 Show progress in notifications:                
             </label>            
             <div class="col-4">
-                <input class="form-check-input" type="checkbox" id="chbProgressNotifications" onclick="progressNotifications();" />            
+                <input class="form-check-input" type="checkbox" id="chbProgressNotifications" />            
             </div>
         </div>
         <div class="form-group row">
@@ -39,7 +39,7 @@
                 Threshold for high similarity:
             </label>
             <div class="col-4">
-                <input class="form-control" id="tbxHighTH" type="number" min="51" max="99" onchange="setHighTH();" />
+                <input class="form-control" id="tbxHighTH" type="number" min="51" max="99" />
             </div>
         </div>
         <div class="form-group row">
@@ -47,7 +47,7 @@
                 Threshold for low similarity:
             </label>
             <div class="col-4">
-                <input class="form-control" id="tbxLowTH" type="number" min="1" max="50" onchange="setLowTH();" />
+                <input class="form-control" id="tbxLowTH" type="number" min="1" max="50" />
             </div>
         </div>
         <div class="form-group row">
@@ -55,7 +55,7 @@
                 Color for high similarity:
             </label>
             <div class="col-4">
-                <input class="form-control" id="clrHighTH" type="color" onchange="setHighTHColor();" />
+                <input class="form-control" id="clrHighTH" type="color" />
             </div>
         </div>
         <div class="form-group row">
@@ -63,7 +63,7 @@
                 Color for mid similarity:
             </label>
             <div class="col-4">
-                <input class="form-control" id="clrMidTH" type="color" onchange="setMidTHColor();" />
+                <input class="form-control" id="clrMidTH" type="color" />
             </div>
         </div>
         <div class="form-group row">
@@ -71,9 +71,10 @@
                 Color for low similarity:
             </label>
             <div class="col-4">
-                <input class="form-control" id="clrLowTH" type="color" onchange="setLowTHColor();" />
+                <input class="form-control" id="clrLowTH" type="color" />
             </div>
         </div>
+        <button id="reprocessButton">Reprocess</button>
 
         <hr />
         <div id="status" >Default</div>

--- a/html/popup.html
+++ b/html/popup.html
@@ -7,15 +7,16 @@
             margin: 20px 20px 10px 20px;
             min-width: 400px;
         }        
-        div#status {            
-            margin:auto;
-            width: 50%;
-            text-align: center;
-            height: 30px;
+        #status {           
+            text-align: right;
         }
         .form-group {
             margin-top: 0;
             margin-bottom: 5px;
+        }
+        .col-form-label {
+          padding-bottom: 0px;
+          padding-top: 0px;
         }
         input[type=color].form-control {
             padding: 3px;
@@ -24,8 +25,9 @@
 	  </head>
 	  <body>
         <h5>Goodreads Compare Books configuration</h5>
+
         <hr>
-        
+
         <div class="form-group row">          
             <label class="col-8 form-check-label" for="chbProgressNotifications">
                 Show progress in notifications:                
@@ -34,22 +36,47 @@
                 <input class="form-check-input" type="checkbox" id="chbProgressNotifications" />            
             </div>
         </div>
+        
+        <hr/>
+
+        <h6>High similarity thresholds:</h6>
         <div class="form-group row">
-            <label class="col-8 col-form-label" for="tbxHighTH">
-                Threshold for high similarity:
+            <label class="col-8 col-form-label" for="minBooksHighTH">
+                Minimum # books in common:
             </label>
             <div class="col-4">
-                <input class="form-control" id="tbxHighTH" type="number" min="51" max="99" />
+                <input class="form-control" id="minBooksHighTH" type="number" min="15" />
+            </div>
+        </div>
+        <div class="form-group row">
+          <label class="col-8 col-form-label" for="tbxHighTH">
+            Minimum percent compatible:
+          </label>
+          <div class="col-4">
+              <input class="form-control" id="tbxHighTH" type="number" min="51" max="99" />
+          </div>
+      </div>
+
+      <hr>
+
+      <h6>Low similarity thresholds:</h6>
+        <div class="form-group row">
+            <label class="col-8 col-form-label" for="maxBooksLowTH">
+                Maximum # books in common:
+            </label>
+            <div class="col-4">
+                <input class="form-control" id="maxBooksLowTH" type="number" max="15" />
             </div>
         </div>
         <div class="form-group row">
             <label class="col-8 col-form-label" for="tbxLowTH">
-                Threshold for low similarity:
+              Maximum percent compatible:
             </label>
             <div class="col-4">
                 <input class="form-control" id="tbxLowTH" type="number" min="1" max="50" />
             </div>
         </div>
+        <hr>
         <div class="form-group row">
             <label class="col-8 col-form-label" for="clrHighTH">
                 Color for high similarity:
@@ -74,10 +101,18 @@
                 <input class="form-control" id="clrLowTH" type="color" />
             </div>
         </div>
-        <button id="reprocessButton">Reprocess</button>
 
         <hr />
-        <div id="status" >Default</div>
+
+        <div class ="form-group row">
+          <div class="col-4">
+            <button id="reprocessButton">Reprocess</button>
+          </div>
+          <div class="col-8">
+              <div id="status" >Default</div>
+          </div>
+        </div>
+        
 
         <script src="../js/popup.js"></script>
 

--- a/js/background.js
+++ b/js/background.js
@@ -3,6 +3,8 @@ function loadConfig() {
       progressNotifications: true,
       highTH: "75",
       lowTH: "40",
+      minBooksHighTH: 15,
+      maxBooksLowTH: 5,
       highTHColor: "#32b849",
       midTHColor: "#ff9f0f",
       lowTHColor: "#ff2025" 
@@ -39,12 +41,13 @@ function setLinksError(links, error) {
 
 function setLink(link, userData) {    
   var compareUrl = compareUrlBase + userData.id;
+  var booksInCommon = Number(userData.booksInCommon);
   var comparison = Number(userData.comparison);
-  var style = "style='color:black;'"
+  var style = "style='color:black;'";
 
-  if(comparison > config.highTH) { // good match
+  if(comparison >= config.highTH && booksInCommon >= config.minBooksHighTH) { // good match
       style = "style='color:"+ config.highTHColor +";'"
-  } else if(comparison < config.lowTH) { // poor match
+  } else if(comparison <= config.lowTH || booksInCommon <= config.maxBooksLowTH) { // poor match
       style = "style='color:"+ config.lowTHColor +";'"
   } else { // middle
       style = "style='color:"+ config.midTHColor +";'"
@@ -52,7 +55,7 @@ function setLink(link, userData) {
 
   var tooltip = userData.comparisonText + "\n" + userData.booksInCommonText;
 
-  link.after("<a class='goodTooltip' "+style+" title='"+tooltip+"' href='"+compareUrl+"'> ["+userData.comparison+"% / "+userData.booksInCommon+"] </a>");
+  link.after("<a class='goodTooltip' "+style+" title='"+tooltip+"' href='"+compareUrl+"'> ["+userData.comparison+"% / "+booksInCommon+"] </a>");
       
   tippy(".goodTooltip");
 }

--- a/js/background.js
+++ b/js/background.js
@@ -1,164 +1,182 @@
-
 function loadConfig() {
-    chrome.storage.local.get({
-        progressNotifications: true,
-        highTH: "75",
-        lowTH: "40",
-        highTHColor: "#32b849",
-        midTHColor: "#ff9f0f",
-        lowTHColor: "#ff2025" 
-    }, function(items) {
-        config = items;
-        startProcessing();
-    });
+  chrome.storage.local.get({
+      progressNotifications: true,
+      highTH: "75",
+      lowTH: "40",
+      highTHColor: "#32b849",
+      midTHColor: "#ff9f0f",
+      lowTHColor: "#ff2025" 
+  }, function(items) {
+      config = items;
+      startProcessing();
+  });
 }
 
 function setLinks(userData) {
-    countProcessed++;
-    if(config.progressNotifications) {
-        progress.setContent('Processed ' +countProcessed+ ' from ' + countAll)
-            .delay(5)
-            .push('Processed ' +countProcessed+ ' from ' + countAll);
-    }
+  countProcessed++;
+  if(config.progressNotifications) {
+      progress.setContent('Processed ' +countProcessed+ ' from ' + countAll)
+          .delay(5)
+          .push('Processed ' +countProcessed+ ' from ' + countAll);
+  }
 
-    userData.links.forEach(link => {
-        setLink(link, userData);
-    });
+  userData.links.forEach(link => {
+      setLink(link, userData);
+  });
 }
 
 function setLinksError(links, error) {
-    countProcessed++;
-    if(config.progressNotifications) {
-        progress.setContent('Processed ' +countProcessed+ ' from ' + countAll)
-            .delay(5)
-            .push('Processed ' +countProcessed+ ' from ' + countAll);
-    }
-    links.forEach(link => {
-        setLinkError(link, error);
-    });
+  countProcessed++;
+  if(config.progressNotifications) {
+      progress.setContent('Processed ' +countProcessed+ ' from ' + countAll)
+          .delay(5)
+          .push('Processed ' +countProcessed+ ' from ' + countAll);
+  }
+  links.forEach(link => {
+      setLinkError(link, error);
+  });
 }
 
 function setLink(link, userData) {    
-    var compareUrl = compareUrlBase + userData.id;
-    var comparison = Number(userData.comparison);
-    var style = "style='color:black;'"
+  var compareUrl = compareUrlBase + userData.id;
+  var comparison = Number(userData.comparison);
+  var style = "style='color:black;'"
 
-    if(comparison > config.highTH) { // good match
-        style = "style='color:"+ config.highTHColor +";'"
-    } else if(comparison < config.lowTH) { // poor match
-        style = "style='color:"+ config.lowTHColor +";'"
-    } else { // middle
-        style = "style='color:"+ config.midTHColor +";'"
-    }
+  if(comparison > config.highTH) { // good match
+      style = "style='color:"+ config.highTHColor +";'"
+  } else if(comparison < config.lowTH) { // poor match
+      style = "style='color:"+ config.lowTHColor +";'"
+  } else { // middle
+      style = "style='color:"+ config.midTHColor +";'"
+  }
 
-    var tooltip = userData.comparisonText + "\n" + userData.booksInCommonText;
+  var tooltip = userData.comparisonText + "\n" + userData.booksInCommonText;
 
-    link.after("<a class='goodTooltip' "+style+" title='"+tooltip+"' href='"+compareUrl+"'> ["+userData.comparison+"% / "+userData.booksInCommon+"] </a>");
-        
-    tippy(".goodTooltip");
+  link.after("<a class='goodTooltip' "+style+" title='"+tooltip+"' href='"+compareUrl+"'> ["+userData.comparison+"% / "+userData.booksInCommon+"] </a>");
+      
+  tippy(".goodTooltip");
 }
 
 function setLinkError(link, error) {    
-    var userName = link.text();
-    link.text(userName + " (" + error + ")");
+  var userName = link.text();
+  link.text(userName + " (" + error + ")");
 }
 
 function processCompareData(userData, compareData){
-    
-    var para = $("p.readable", compareData);
-    if(para.length !== 0) {
-        var matchComparison = para[0].innerText.match(reComparison);
-        if(matchComparison !== null) {
-            var comparison = matchComparison[0];
-            userData.comparison = comparison;
-            userData.comparisonText = para[0].innerText;            
-        } else {
-            setLinksError(userData.links, para.text());
-        }
+  
+  var para = $("p.readable", compareData);
+  if(para.length !== 0) {
+      var matchComparison = para[0].innerText.match(reComparison);
+      if(matchComparison !== null) {
+          var comparison = matchComparison[0];
+          userData.comparison = comparison;
+          userData.comparisonText = para[0].innerText;            
+      } else {
+          setLinksError(userData.links, para.text());
+      }
 
-        var div = $("div.readable:nth-child(2)", compareData);
-        if(div.length !== 0) {
+      var div = $("div.readable:nth-child(2)", compareData);
+      if(div.length !== 0) {
 
-            var matchCommon = div.text().match(reCommon);
-            if(matchCommon !== null) {
-                var common = matchCommon[0];
-                userData.booksInCommon = common;
-            }
-            userData.booksInCommonText = div.text().trim();
-        }
+          var matchCommon = div.text().match(reCommon);
+          if(matchCommon !== null) {
+              var common = matchCommon[0];
+              userData.booksInCommon = common;
+          }
+          userData.booksInCommonText = div.text().trim();
+      }
 
-        setLinks(userData);
+      setLinks(userData);
 
-    } else {
-        // probably private
-        setLinksError(userData.links, "probably private");
-    }
+  } else {
+      // probably private
+      setLinksError(userData.links, "probably private");
+  }
 }
 
 function cacheThisUser(link) {
-    
-    var userHref = link.attr("href");
-    var userId = userHref.split('/').pop();    
+  
+  var userHref = link.attr("href");
+  var userId = userHref.split('/').pop();    
 
-    if(userId in userCache) {
-        var userData = userCache[userId];
-        userData.links.push(link);
-    } else {
-        var userData = { 
-            id: userId, 
-            links: [], 
-            comparison: '',
-            comparisonText: '', 
-            booksInCommon: '',
-            booksInCommonText: '' 
-        };
-        userData.links.push(link);
-        userCache.set(userId, userData);
-    }
+  if(userId in userCache) {
+      var userData = userCache[userId];
+      userData.links.push(link);
+  } else {
+      var userData = { 
+          id: userId, 
+          links: [], 
+          comparison: '',
+          comparisonText: '', 
+          booksInCommon: '',
+          booksInCommonText: '' 
+      };
+      userData.links.push(link);
+      userCache.set(userId, userData);
+  }
 }
 
 function startProcessing() {
-    // this works in discussions
-    $("span.commentAuthor a").each(function (){
-        var link = $(this);
-        cacheThisUser(link);
-    });
 
-    // this works on main page
-    $("a.gr-user__profileLink").each(function (){
-        var link = $(this);    
-        cacheThisUser(link);
-    });
+  // reset global variables, remove previous processing artifacts
+  userCache = new Map();
+  countAll = 0;
+  countProcessed = 0;
+  $(".goodTooltip").remove();
 
-    // this works on group page
-    $("a.userName").each(function (){
-        var link = $(this);    
-        cacheThisUser(link);
-    });
+  // this works in discussions
+  $("span.commentAuthor a").each(function (){
+      var link = $(this);
+      cacheThisUser(link);
+  });
 
-    // this works on people page
-    $("table.tableList tr td:nth-child(3) a:nth-child(1)").each(function (){
-        var link = $(this);    
-        cacheThisUser(link);
-    });
+  // this works on main page
+  $("a.gr-user__profileLink").each(function (){
+      var link = $(this);    
+      cacheThisUser(link);
+  });
 
-    countAll = userCache.size;
-    
-    if(config.progressNotifications) {    
-        progress.delay(5).push('Spotted '+ countAll +' users on page. Processing starts now. ');
-    }
-    
-    for (var [key, value] of userCache) {    
-        var userId = key;
-        var userData = value;
-        var compareUrl = compareUrlBase + userId;
-        $.ajax({
-            url: compareUrl, 
-            context: userData
-        }).done(function(compareData) {
-            processCompareData(this, compareData);        
-        });
-    }
+  // this works on group page
+  $("a.userName").each(function (){
+      var link = $(this);    
+      cacheThisUser(link);
+  });
+
+  // this works on book pages' reviews
+  $("a.user").each(function (){
+    var link = $(this);    
+    cacheThisUser(link);
+});
+
+  // this works on updates feed
+  $("gr-user__profileLink").each(function (){
+    var link = $(this);    
+    cacheThisUser(link);
+});
+
+  // this works on people page
+  $("table.tableList tr td:nth-child(3) a:nth-child(1)").each(function (){
+      var link = $(this);    
+      cacheThisUser(link);
+  });
+
+  countAll = userCache.size;
+  
+  if(config.progressNotifications) {    
+      progress.delay(5).push('Spotted '+ countAll +' users on page. Processing starts now. ');
+  }
+  
+  for (var [key, value] of userCache) {    
+      var userId = key;
+      var userData = value;
+      var compareUrl = compareUrlBase + userId;
+      $.ajax({
+          url: compareUrl, 
+          context: userData
+      }).done(function(compareData) {
+          processCompareData(this, compareData);        
+      });
+  }
 
 }
 
@@ -177,4 +195,9 @@ progress.dismiss();
 
 loadConfig();
 
-
+chrome.runtime.onMessage.addListener( function(request,sender,sendResponse)
+{
+if (request.message === 'reprocess') {
+  startProcessing();
+};
+});

--- a/js/popup.js
+++ b/js/popup.js
@@ -1,82 +1,72 @@
 
 // TODO Set icon for browser action
 
-
-function progressNotifications() {
-    var chb = document.getElementById('chbProgressNotifications');
-    saveSetting("progressNotifications", chb.checked);
-}
-
-function saveProgressNotifications(checked) {
-    chrome.storage.local.set({
-        progressNotifications: checked
-      }, function() {
-        setStatus("Configuration saved");
-      });
-}
-
 function restore_options() {
-    chrome.storage.local.get({
-    progressNotifications: true,
-    highTH: "75",
-    lowTH: "40",
-    highTHColor: "#32b849",
-    midTHColor: "#ff9f0f",
-    lowTHColor: "#ff2025" 
-    }, function(items) {
-      document.getElementById('tbxHighTH').value = items.highTH;
-      document.getElementById('tbxLowTH').value = items.lowTH;
-      document.getElementById('clrHighTH').value = items.highTHColor;
-      document.getElementById('clrMidTH').value = items.midTHColor;
-      document.getElementById('clrLowTH').value = items.lowTHColor;
-      document.getElementById('chbProgressNotifications').checked = items.progressNotifications;
-      setStatus("Configuration restored");
-    });
-  }
+  chrome.storage.local.get({
+  progressNotifications: true,
+  highTH: "75",
+  lowTH: "40",
+  highTHColor: "#32b849",
+  midTHColor: "#ff9f0f",
+  lowTHColor: "#ff2025" 
+  }, function(items) {
+    document.getElementById('tbxHighTH').value = items.highTH;
+    document.getElementById('tbxLowTH').value = items.lowTH;
+    document.getElementById('clrHighTH').value = items.highTHColor;
+    document.getElementById('clrMidTH').value = items.midTHColor;
+    document.getElementById('clrLowTH').value = items.lowTHColor;
+    document.getElementById('chbProgressNotifications').checked = items.progressNotifications;
+    setStatus("Configuration restored");
+  });
+}
 
-  document.addEventListener('DOMContentLoaded', domLoaded);
+document.addEventListener('DOMContentLoaded', domLoaded);
 
+function domLoaded(){
+  restore_options();
+  initializeSettingInput('change', 'tbxHighTH', 'value', 'highTH');
+  initializeSettingInput('change', 'tbxLowTH', 'value', 'lowTH');
+  initializeSettingInput('change', 'clrHighTH', 'value', 'highTHColor');
+  initializeSettingInput('change', 'clrMidTH', 'value', 'midTHColor');
+  initializeSettingInput('change', 'clrLowTH', 'value', 'lowTHColor');
+  initializeSettingInput('click', 'chbProgressNotifications', 'checked', 'progressNotifications');
+  initializeReprocessButton();
+}
 
-  function domLoaded(){
-    restore_options();
-  }
+function initializeSettingInput(event, elementId, inputValueKey, settingKey) {
+  var el = document.getElementById(elementId);
+  el.addEventListener(event, function() {
+    saveSetting(settingKey, el[inputValueKey]);
+  });
+};
 
-
+var timeout = null;
 
 function setStatus(message) {  
   var status = document.getElementById('status');
   status.textContent = message;
-  setTimeout(function() {
+
+  if (timeout) clearTimeout(timeout);
+  timeout = setTimeout(function() {
     status.textContent = '';
   }, 1500);
 }
 
-function setHighTH(){
-  var tbx = document.getElementById('tbxHighTH');
-  saveSetting("highTH", tbx.value);
+function initializeReprocessButton(){
+  var reprocessButton = document.getElementById('reprocessButton');  
+  reprocessButton.addEventListener('click', function() { 
+    sendReprocessMessage();
+    window.close();
+  });
 }
 
-function setLowTH(){
-  var tbx = document.getElementById('tbxLowTH');
-  saveSetting("lowTH", tbx.value);
+// useful for processing lazyloaded content (eg., book page reviews)
+function sendReprocessMessage() {
+  chrome.tabs.query({currentWindow: true, active: true}, function (tabs){
+    var activeTab = tabs[0];
+    chrome.tabs.sendMessage(activeTab.id, {"message": "reprocess"});
+  });
 }
-
-function setLowTHColor(){
-  var clr = document.getElementById('clrLowTH');
-  saveSetting("lowTHColor", clr.value);
-}
-
-function setMidTHColor(){
-  var clr = document.getElementById('clrMidTH');
-  saveSetting("midTHColor", clr.value);
-}
-
-function setHighTHColor(){
-  var clr = document.getElementById('clrHighTH');
-  saveSetting("highTHColor", clr.value);
-}
-
-
 
 function saveSetting(settingKey, value) {
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -6,12 +6,16 @@ function restore_options() {
   progressNotifications: true,
   highTH: "75",
   lowTH: "40",
+  minBooksHighTH: 15,
+  maxBooksLowTH: 5,
   highTHColor: "#32b849",
   midTHColor: "#ff9f0f",
   lowTHColor: "#ff2025" 
   }, function(items) {
     document.getElementById('tbxHighTH').value = items.highTH;
     document.getElementById('tbxLowTH').value = items.lowTH;
+    document.getElementById('minBooksHighTH').value = items.minBooksHighTH;
+    document.getElementById('maxBooksLowTH').value = items.maxBooksLowTH;
     document.getElementById('clrHighTH').value = items.highTHColor;
     document.getElementById('clrMidTH').value = items.midTHColor;
     document.getElementById('clrLowTH').value = items.lowTHColor;
@@ -26,6 +30,8 @@ function domLoaded(){
   restore_options();
   initializeSettingInput('change', 'tbxHighTH', 'value', 'highTH');
   initializeSettingInput('change', 'tbxLowTH', 'value', 'lowTH');
+  initializeSettingInput('change', 'minBooksHighTH', 'value', 'minBooksHighTH');
+  initializeSettingInput('change', 'maxBooksLowTH', 'value', 'maxBooksLowTH');
   initializeSettingInput('change', 'clrHighTH', 'value', 'highTHColor');
   initializeSettingInput('change', 'clrMidTH', 'value', 'midTHColor');
   initializeSettingInput('change', 'clrLowTH', 'value', 'lowTHColor');


### PR DESCRIPTION
Chrome extensions don't permit inline functions, so popup.js's input event functions were throwing an error rather than saving their state. This commit adds eventListeners in popup.js instead. 

Also, this commit adds a new "reprocess" button to popup.js allowing a user to rescan the page for new user links. This is important on several Goodreads pages that lazyload user info - like Book pages, which lazyload reviews.